### PR TITLE
Implementing address_byte_prefix for addresses/transactions

### DIFF
--- a/pybtc/classes/address.py
+++ b/pybtc/classes/address.py
@@ -1,9 +1,11 @@
-from pybtc.constants import *
-from pybtc.opcodes import *
+from pybtc.constants import (MAINNET_PRIVATE_KEY_UNCOMPRESSED_PREFIX,
+                             TESTNET_PRIVATE_KEY_UNCOMPRESSED_PREFIX,
+                             TESTNET_PRIVATE_KEY_COMPRESSED_PREFIX)
+from pybtc.opcodes import OP_CHECKSIG, OP_CHECKMULTISIG
 from pybtc.functions.tools import bytes_from_hex, int_to_var_int
 from pybtc.functions.script import op_push_data, decode_script
 from pybtc.functions.hash import hash160, sha256
-from pybtc.functions.address import  hash_to_address, public_key_to_p2sh_p2wpkh_script
+from pybtc.functions.address import hash_to_address, public_key_to_p2sh_p2wpkh_script
 from pybtc.functions.key import (create_private_key,
                                  private_key_to_wif,
                                  is_wif_valid,
@@ -11,7 +13,8 @@ from pybtc.functions.key import (create_private_key,
                                  is_public_key_valid,
                                  private_to_public_key)
 
-class PrivateKey():
+
+class PrivateKey:
     """
     The class for creating private key object.
 
@@ -20,7 +23,6 @@ class PrivateKey():
     :param compressed: (optional) if set to True private key corresponding compressed public key,
                        by default set to True. Recommended use only compressed public key.
     :param testnet: (optional) if set to True mean that this private key for testnet Bitcoin network.
-
     """
     def __init__(self, key=None, compressed=True, testnet=False):
 
@@ -71,28 +73,27 @@ class PrivateKey():
         return self.wif
 
 
-class PublicKey():
+class PublicKey:
     """
     The class for public key object.
 
     :param key:  one of this types allowed:
-    
+
                 - private key is instance of ``PrivateKey`` class
                 - private key HEX encoded string
                 - private key 32 bytes string
                 - private key in WIF format
                 - public key in HEX encoded string
                 - public key [33/65] bytes string
-                
-                In case no key specified with HEX or bytes string you have to provide flag for testnet 
+
+                In case no key specified with HEX or bytes string you have to provide flag for testnet
                 and compressed key. WIF format and ``PrivateKey`` instance already contain this flags.
-                For HEX or bytes public key only testnet flag has the meaning, comressed flag is determined 
+                For HEX or bytes public key only testnet flag has the meaning, comressed flag is determined
                 according to the length of key.
-                
+
     :param compressed: (optional) if set to True private key corresponding compressed public key,
                        by default set to True. Recommended use only compressed public key.
     :param testnet: (optional) if set to True mean that this private key for testnet Bitcoin network.
-
     """
     def __init__(self, key, compressed=True, testnet=False):
         if isinstance(key, str):
@@ -129,17 +130,17 @@ class PublicKey():
         return self.hex
 
 
-class Address():
+class Address:
     """
     The class for Address object.
 
     :param key: (optional) one of this types allowed:
-    
+
                 - private key WIF format
                 - instance of ``PrivateKey``
                 - private key HEX encoded string
                 - instance of ``PublicKey``
-                
+
                 In case no key specified new Address will be created with random keys.
     :param address_type: (optional) P2PKH, PUBKEY, P2WPKH, P2SH_P2WPKH, by default P2WPKH.
     :param compressed: (optional) if set to True private key corresponding compressed public key,
@@ -237,15 +238,13 @@ class ScriptAddress():
 
         :param n: count of required signatures (max 15).
         :param m: count of total addresses of participants (max 15).
-        :param list address_list: addresses list, allowed types:
-                       
+        :param list address_list: addresses list, allowed types: - TODO
+
                              - bytes or HEX encoded private key
                              - private key in WIF format
                              - PrivateKey instance,
                              - bytes or HEX encoded public key
                              - PublicKey instance
-                             
-                             
         """
         if n > 15 or m > 15 or n > m or n < 1 or m < 1:
             raise TypeError("invalid n of m maximum 15 of 15 multisig allowed")

--- a/pybtc/functions/address.py
+++ b/pybtc/functions/address.py
@@ -1,6 +1,19 @@
-from pybtc.opcodes import *
-from pybtc.constants import *
-
+from pybtc.opcodes import OP_HASH160, OP_EQUAL, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG, OP_0
+from pybtc.constants import (MAINNET_ADDRESS_PREFIX,
+                             TESTNET_ADDRESS_PREFIX,
+                             TESTNET_ADDRESS_PREFIX_2,
+                             TESTNET_ADDRESS_BYTE_PREFIX,
+                             MAINNET_ADDRESS_BYTE_PREFIX,
+                             MAINNET_SCRIPT_ADDRESS_BYTE_PREFIX,
+                             TESTNET_SCRIPT_ADDRESS_BYTE_PREFIX,
+                             TESTNET_SEGWIT_ADDRESS_BYTE_PREFIX,
+                             TESTNET_SEGWIT_ADDRESS_PREFIX,
+                             MAINNET_SEGWIT_ADDRESS_BYTE_PREFIX,
+                             MAINNET_SEGWIT_ADDRESS_PREFIX,
+                             ADDRESS_PREFIX_LIST,
+                             TESTNET_SCRIPT_ADDRESS_PREFIX,
+                             MAINNET_SCRIPT_ADDRESS_PREFIX,
+                             SCRIPT_TYPES)
 from pybtc.functions.tools import bytes_from_hex, get_bytes
 from pybtc.functions.hash import double_sha256, hash160
 from pybtc.functions.encode import (encode_base58,
@@ -42,7 +55,8 @@ def public_key_to_address(pubkey, testnet=False, p2sh_p2wpkh=False, witness_vers
                            witness_version=witness_version)
 
 
-def hash_to_address(address_hash, testnet=False, script_hash=False, witness_version=0):
+def hash_to_address(address_hash, testnet=False, script_hash=False,
+                    witness_version=0, address_byte_prefix=MAINNET_ADDRESS_BYTE_PREFIX):
     """
     Get address from public key/script hash. In case PUBKEY, P2PKH, P2PKH public key/script hash is SHA256+RIPEMD160,
     P2WSH script hash is SHA256.
@@ -64,7 +78,7 @@ def hash_to_address(address_hash, testnet=False, script_hash=False, witness_vers
             if testnet:
                 prefix = TESTNET_ADDRESS_BYTE_PREFIX
             else:
-                prefix = MAINNET_ADDRESS_BYTE_PREFIX
+                prefix = address_byte_prefix
             address_hash = b"%s%s" % (prefix, address_hash)
             address_hash += double_sha256(address_hash)[:4]
             return encode_base58(address_hash)
@@ -85,7 +99,7 @@ def hash_to_address(address_hash, testnet=False, script_hash=False, witness_vers
         prefix = TESTNET_SEGWIT_ADDRESS_BYTE_PREFIX
         hrp = TESTNET_SEGWIT_ADDRESS_PREFIX
     else:
-        prefix = MAINNET_SEGWIT_ADDRESS_BYTE_PREFIX
+        prefix = address_byte_prefix
         hrp = MAINNET_SEGWIT_ADDRESS_PREFIX
 
     address_hash = b"%s%s" % (witness_version.to_bytes(1, "big"),
@@ -116,11 +130,11 @@ def address_to_hash(address, hex=True):
 
 def address_type(address, num=False):
     """
-    Get address type.   
+    Get address type.
 
     :param address: address in base58 or bech32 format.
     :param num: (optional) If set to True return type in numeric format, by default is False.
-    :return: address type in string or numeric format. 
+    :return: address type in string or numeric format.
     """
     if address[0] in (TESTNET_SCRIPT_ADDRESS_PREFIX,
                       MAINNET_SCRIPT_ADDRESS_PREFIX):
@@ -144,10 +158,10 @@ def address_type(address, num=False):
 
 def address_net_type(address):
     """
-    Get address network type.   
+    Get address network type.
 
     :param address: address in base58 or bech32 format.
-    :return: address network type in string format or None. 
+    :return: address network type in string format or None.
     """
     if address[0] in (MAINNET_SCRIPT_ADDRESS_PREFIX,
                       MAINNET_ADDRESS_PREFIX):


### PR DESCRIPTION
- ``address_byte_prefix`` is now available as an option for transactions and addresses through setting the ``address_byte_prefix`` parameter. If ``address_byte_prefix`` isn't set, just use ``MAINNET_ADDRESS_BYTE_PREFIX``.
- Blanket imports are removed and replaced for what actually gets imported.
- Unnecessary ``()`` is removed from classes