### PR TITLE
Fix Shamir leading coefficient generation

### DIFF
--- a/pybtc/functions/shamir.py
+++ b/pybtc/functions/shamir.py
@@ -115,13 +115,17 @@ def split_secret(threshold, total,  secret, index_bits=8):
         q = [b]
 
         for i in range(threshold - 1):
-            if e_i < len(e):
-                a = e[e_i]
-                e_i += 1
-            else:
-                e = generate_entropy(hex=False)
-                a = e[0]
-                e_i = 1
+            is_leading_coefficient = i == threshold - 2
+            while True:
+                if e_i < len(e):
+                    a = e[e_i]
+                    e_i += 1
+                else:
+                    e = generate_entropy(hex=False)
+                    a = e[0]
+                    e_i = 1
+                if not is_leading_coefficient or a != 0:
+                    break
             q.append(a)
 
         for z in shares_indexes:

--- a/tests/test_shamir_functions.py
+++ b/tests/test_shamir_functions.py
@@ -79,6 +79,19 @@ def test_secret_spliting():
         shamir.split_secret(20, 20, secret, index_bits = 2)
 
 
+def test_split_secret_regenerates_zero_leading_coefficient(monkeypatch):
+    entropy_chunks = iter([bytes([7, 0, 11])])
+    monkeypatch.setattr(shamir, "generate_entropy", lambda hex=False: next(entropy_chunks))
+
+    secret = b"*"
+    shares = shamir.split_secret(3, 3, secret)
+    keys = list(shares)
+    two_shares = {keys[0]: shares[keys[0]], keys[1]: shares[keys[1]]}
+
+    assert shamir.restore_secret(two_shares) != secret
+    assert shamir.restore_secret(shares) == secret
+
+
 
 
 def test__interpolation():


### PR DESCRIPTION
## Summary
- Prevent generated Shamir polynomials from using `0` as the highest-degree coefficient.
- Leave secret restoration compatible with existing shares.
- Add a regression test that forces a zero leading coefficient and verifies two shares no longer recover a 3-of-3 secret.

This applies the same defensive fix to the Python implementation linked from the Bitaps Shamir bug bounty page.

## Verification
- Direct Shamir regression script with stubbed entropy: passed
- `PYTHONPYCACHEPREFIX=/private/tmp/pybtc-pycache .venv/bin/python -m py_compile pybtc/functions/shamir.py tests/test_shamir_functions.py`
- `git diff --check`

Note: full `pytest tests/test_shamir_functions.py -q` could not collect in this environment because the package imports compiled crypto extensions before the Shamir test module; local editable install is blocked by missing `autoreconf` for `libsecp256k1`.

Bounty payout address if accepted: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`