### PR TITLE
fix: Path Traversal Safety for pybtc

### DIFF
--- a/setup_tools.py
+++ b/setup_tools.py
@@ -61,6 +61,12 @@ def download_library(command):
                 content = BytesIO(r.read())
                 content.seek(0)
                 with tarfile.open(fileobj=content) as tf:
+                    # Prevent Tar Slip (Path Traversal)
+                    base_path = os.path.realpath(os.getcwd())
+                    for member in tf.getmembers():
+                        member_path = os.path.realpath(os.path.join(base_path, member.name))
+                        if not member_path.startswith(base_path + os.sep) and member_path != base_path:
+                            raise Exception('Attempted Path Traversal in Tar File')
                     dirname = tf.getnames()[0].partition('/')[0]
                     tf.extractall()
                 shutil.move(dirname, libdir)


### PR DESCRIPTION
Hey there! 👋

I was reviewing the codebase and noticed a potential security issue that I thought I'd flag and fix.

## What I found

- **[HIGH] path_traversal** in `setup_tools.py`: The `tarfile.extractall()` method is used without validating the paths of the files inside the tarball. This is vulnerab

## What I changed

The fix is minimal and targeted — I added proper validation/sanitization where user-controlled or untrusted data enters sensitive operations. No changes to existing functionality or public APIs.

## Testing

Ran the existing test suite locally, everything passes. The change is backward-compatible.

Happy to discuss if you have questions!

Relates to: https://github.com/bitaps-com/pybtc/issues/64

---
💛 If this helps, feel free to support my open-source security work: `0x1478f1BDEACc7b434b4405350A15993cDcddc79F`